### PR TITLE
Tweak updating of defconfigs for dep checker tool

### DIFF
--- a/doitlk-linux-build.sh
+++ b/doitlk-linux-build.sh
@@ -18,6 +18,16 @@ case $1 in
 		;;
 	"defconfig")
 		make $MAKEFLAGS defconfig
+		./scripts/config --disable CONFIG_DEBUG_INFO_NONE
+		./scripts/config --enable CONFIG_DEBUG_INFO
+		./scripts/config --enable CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT 
+		./scripts/config --disable CONFIG_DEBUG_INFO_REDUCED
+		./scripts/config --disable CONFIG_DEBUG_INFO_SPLIT
+		./scripts/config --disable CONFIG_DEBUG_INFO_BTF
+		./scripts/config --enable CONFIG_PAHOLE_HAS_SPLIT_BTF 
+		./scripts/config --enable CONFIG_PAHOLE_HAS_BTF_TAG
+		./scripts/config --disable CONFIG_GDB_SCRIPTS
+		./scripts/config --disable CONFIG_DEBUG_EFI
 		;;
 	"fast")	
 		make $MAKEFLAGS -j$(nproc) $2 2> build_output.ll

--- a/random_search_broken_deps.py
+++ b/random_search_broken_deps.py
@@ -48,9 +48,17 @@ def restoreBrokenDeps():
         print("Restored " + str(len(prevIDedBrokenDeps)) + " broken dep(s)")
 
 def updateConfig():
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_DEBUG_INFO_NONE"])
     subprocess.run(["./scripts/config", "--enable", "CONFIG_DEBUG_INFO"])
-    subprocess.run(["./scripts/config", "--enable", "CONFIG_DEBUG_INFO"])
+    subprocess.run(["./scripts/config", "--enable", "CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAU"])
     subprocess.run(["./scripts/config", "--enable", "CONFIG_LTO_NONE"])
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_DEBUG_INFO_REDUCED"])
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_DEBUG_INFO_SPLIT"])
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_DEBUG_INFO_BTF"])
+    subprocess.run(["./scripts/config", "--enable", "CONFIG_PAHOLE_HAS_SPLIT_BTF"])
+    subprocess.run(["./scripts/config", "--enable", "CONFIG_PAHOLE_HAS_BTF_TAG"])
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_GDB_SCRIPTS"])
+    subprocess.run(["./scripts/config", "--disable", "CONFIG_DEBUG_EFI"])
 
 def main(runs=1):
     print("Restoring broken deps ...")


### PR DESCRIPTION
Add a few options s.t. defconfig won't ask any questions anymore before
the build after enabling debug info (required for dep checker).